### PR TITLE
Doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In the event that a set of distributed processes are moved, for example
 when restarting an MPI job, functions will migrate files from their original
 locations to the new locations where the processes are running.
 
-Usage is documented in src/shuffile.h.
+Usage is documented in [src/shuffile.h]() and the [User API docs](https://ecp-veloc.github.io/component-user-docs/group__shuffile.html).
 
 # Building
 

--- a/src/shuffile.h
+++ b/src/shuffile.h
@@ -4,6 +4,16 @@
 #include "mpi.h"
 #include "kvtree.h"
 
+/** \defgroup shuffile Shuffile
+ *  \brief Shuffle files between MPI ranks
+ *
+ * Files are registered with Used during restart, shuffile will move a
+ * file to the 'owning' MPI rank. */
+
+/** \file shuffile.h
+ *  \ingroup shuffile
+ *  \brief shuffle files between mpi ranks */
+
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 extern "C" {
@@ -12,38 +22,38 @@ extern "C" {
 #define SHUFFILE_SUCCESS (0)
 #define SHUFFILE_FAILURE (1)
 
-/* initialize library */
+/** initialize library */
 int shuffile_init();
 
-/* shutdown library */
+/** shutdown library */
 int shuffile_finalize();
 
-/* associate a set of files with the calling process,
+/** associate a set of files with the calling process,
  * name of process is taken as rank in comm,
  * collective across processes in comm */
 int shuffile_create(
-  MPI_Comm comm,       /* IN - group of processes participating in shuffle */
-  MPI_Comm comm_store, /* IN - group of processes sharing a shuffle file, subgroup of comm */
-  int numfiles,        /* IN - number of files */
-  const char** files,  /* IN - array of file names */
-  const char* name     /* IN - path name to file to store shuffle information */
+  MPI_Comm comm,       /**< [IN] - group of processes participating in shuffle */
+  MPI_Comm comm_store, /**< [IN] - group of processes sharing a shuffle file, subgroup of comm */
+  int numfiles,        /**< [IN] - number of files */
+  const char** files,  /**< [IN] - array of file names */
+  const char* name     /**< [IN] - path name to file to store shuffle information */
 );
 
-/* migrate files to owner process, if necessary,
+/** migrate files to owner process, if necessary,
  * collective across processes in comm */
 int shuffile_migrate(
-  MPI_Comm comm,       /* IN - group of processes participating in shuffle */
-  MPI_Comm comm_store, /* IN - group of processes sharing a shuffle file, subgroup of comm */
-  const char* name     /* IN - path name to file containing shuffle info */
+  MPI_Comm comm,       /**< [IN] - group of processes participating in shuffle */
+  MPI_Comm comm_store, /**< [IN] - group of processes sharing a shuffle file, subgroup of comm */
+  const char* name     /**< [IN] - path name to file containing shuffle info */
 );
 
-/* drop association information,
+/** drop association information,
  * which is useful when cleaning up,
  * collective across processes in comm */
 int shuffile_remove(
-  MPI_Comm comm,       /* IN - group of processes participating in shuffle */
-  MPI_Comm comm_store, /* IN - group of processes sharing a shuffle file, subgroup of comm */
-  const char* name     /* IN - path name to file containing shuffle info */
+  MPI_Comm comm,       /**< [IN] - group of processes participating in shuffle */
+  MPI_Comm comm_store, /**< [IN] - group of processes sharing a shuffle file, subgroup of comm */
+  const char* name     /**< [IN] - path name to file containing shuffle info */
 );
 
 /* enable C++ codes to include this header directly */

--- a/src/shuffile.h
+++ b/src/shuffile.h
@@ -1,24 +1,3 @@
-/* All rights reserved. This program and the accompanying materials
- * are made available under the terms of the BSD-3 license which accompanies this
- * distribution in LICENSE.TXT
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the BSD-3  License in
- * LICENSE.TXT for more details.
- *
- * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
- * The Government's rights to use, modify, reproduce, release, perform,
- * display, or disclose this software are subject to the terms of the BSD-3
- * License as provided in Contract No. B609815.
- * Any reproduction of computer software, computer software documentation, or
- * portions thereof marked with this legend must also reproduce the markings.
- *
- * Author: Christopher Holguin <christopher.a.holguin@intel.com>
- *
- * (C) Copyright 2015-2016 Intel Corporation.
- */
-
 #ifndef SHUFFILE_H
 #define SHUFFILE_H
 

--- a/src/shuffile_io.h
+++ b/src/shuffile_io.h
@@ -12,54 +12,56 @@
 #define SHUFFILE_MAX_LINE (1024)
 #endif
 
-/*
-=========================================
-Basic File I/O
-=========================================
-*/
+/** \file shuffile_io.h
+ *  \ingroup shuffile
+ *  \brief some I/O utilities */
 
-/* returns user's current mode as determine by his umask */
+/********************************************************/
+/** \name Basic File I/O */
+///@{
+
+/** returns user's current mode as determine by his umask */
 mode_t shuffile_getmode(int read, int write, int execute);
 
-/* open file with specified flags and mode, retry open a few times on failure */
+/** open file with specified flags and mode, retry open a few times on failure */
 int shuffile_open(const char* file, int flags, ...);
 
-/* close file with an fsync */
+/** close file with an fsync */
 int shuffile_close(const char* file, int fd);
 
-/* get and release file locks */
+/** get and release file locks */
 int shuffile_file_lock_read(const char* file, int fd);
 int shuffile_file_lock_write(const char* file, int fd);
 int shuffile_file_unlock(const char* file, int fd);
 
-/* opens specified file and waits on for an exclusive lock before returning the file descriptor */
+/** opens specified file and waits on for an exclusive lock before returning the file descriptor */
 int shuffile_open_with_lock(const char* file, int flags, mode_t mode);
 
-/* unlocks the specified file descriptor and then closes the file */
+/** unlocks the specified file descriptor and then closes the file */
 int shuffile_close_with_unlock(const char* file, int fd);
 
-/* seek file descriptor to specified position */
+/** seek file descriptor to specified position */
 int shuffile_lseek(const char* file, int fd, off_t pos, int whence);
 
-/* reliable read from opened file descriptor (retries, if necessary, until hard error) */
+/** reliable read from opened file descriptor (retries, if necessary, until hard error) */
 ssize_t shuffile_read(const char* file, int fd, void* buf, size_t size);
 
-/* reliable write to opened file descriptor (retries, if necessary, until hard error) */
+/** reliable write to opened file descriptor (retries, if necessary, until hard error) */
 ssize_t shuffile_write(const char* file, int fd, const void* buf, size_t size);
 
-/* make a good attempt to read from file (retries, if necessary, return error if fail) */
+/** make a good attempt to read from file (retries, if necessary, return error if fail) */
 ssize_t shuffile_read_attempt(const char* file, int fd, void* buf, size_t size);
 
-/* make a good attempt to write to file (retries, if necessary, return error if fail) */
+/** make a good attempt to write to file (retries, if necessary, return error if fail) */
 ssize_t shuffile_write_attempt(const char* file, int fd, const void* buf, size_t size);
 
-/* read line from file into buf with given size */
+/** read line from file into buf with given size */
 ssize_t shuffile_read_line(const char* file, int fd, char* buf, size_t size);
 
-/* write a formatted string to specified file descriptor */
+/** write a formatted string to specified file descriptor */
 ssize_t shuffile_writef(const char* file, int fd, const char* format, ...);
 
-/* logically concatenate n opened files and read count bytes from this logical file into buf starting
+/** logically concatenate n opened files and read count bytes from this logical file into buf starting
  * from offset, pad with zero on end if missing data */
 int shuffile_read_pad_n(
   int n,
@@ -71,7 +73,7 @@ int shuffile_read_pad_n(
   unsigned long* filesizes
 );
 
-/* write to an array of open files with known filesizes and treat them as one single large file */
+/** write to an array of open files with known filesizes and treat them as one single large file */
 int shuffile_write_pad_n(
   int n,
   const char** files,
@@ -82,44 +84,42 @@ int shuffile_write_pad_n(
   unsigned long* filesizes
 );
 
-/* given a filename, return number of bytes in file */
+/** given a filename, return number of bytes in file */
 unsigned long shuffile_file_size(const char* file);
 
-/* tests whether the file or directory exists */
+/** tests whether the file or directory exists */
 int shuffile_file_exists(const char* file);
 
-/* tests whether the file or directory is readable */
+/** tests whether the file or directory is readable */
 int shuffile_file_is_readable(const char* file);
 
-/* tests whether the file or directory is writeable */
+/** tests whether the file or directory is writeable */
 int shuffile_file_is_writeable(const char* file);
 
-/* delete a file */
+/** delete a file */
 int shuffile_file_unlink(const char* file);
 
-/* opens, reads, and computes the crc32 value for the given filename */
+/** opens, reads, and computes the crc32 value for the given filename */
 int shuffile_crc32(const char* filename, uLong* crc);
+///@}
 
-/*
-=========================================
-Directory functions
-=========================================
-*/
+/********************************************************/
+/** \name Directory functions */
+///@{
 
-/* recursively create directory and subdirectories */
+/** recursively create directory and subdirectories */
 int shuffile_mkdir(const char* dir, mode_t mode);
 
-/* remove directory */
+/** remove directory */
 int shuffile_rmdir(const char* dir);
 
-/* write current working directory to buf */
+/** write current working directory to buf */
 int shuffile_getcwd(char* buf, size_t size);
+///@}
 
-/*
-=========================================
-File Copy Functions
-=========================================
-*/
+/********************************************************/
+/** \name File Copy Functions */
+///@{
 
 int shuffile_file_copy(
   const char* src_file,
@@ -127,23 +127,23 @@ int shuffile_file_copy(
   unsigned long buf_size,
   uLong* crc
 );
+///@}
 
-/*
-=========================================
-File compression functions
-=========================================
-*/
+/********************************************************/
+/** \name File compression functions */
+///@{
 
-/* compress the specified file using blocks of size block_size and store as file_dst */
+/** compress the specified file using blocks of size block_size and store as file_dst */
 int shuffile_compress_in_place(const char* file_src, const char* file_dst, unsigned long block_size, int level);
 
-/* uncompress the specified file and store as file_dst */
+/** uncompress the specified file and store as file_dst */
 int shuffile_uncompress_in_place(const char* file_src, const char* file_dst);
 
-/* compress the specified file using blocks of size block_size and store as file_dst */
+/** compress the specified file using blocks of size block_size and store as file_dst */
 int shuffile_compress(const char* file_src, const char* file_dst, unsigned long block_size, int level);
 
-/* uncompress the specified file and store as file_dst */
+/** uncompress the specified file and store as file_dst */
 int shuffile_uncompress(const char* file_src, const char* file_dst);
+///@}
 
 #endif

--- a/src/shuffile_util.h
+++ b/src/shuffile_util.h
@@ -15,33 +15,37 @@ extern char* shuffile_hostname;
 extern int shuffile_mpi_buf_size;
 extern size_t shuffile_page_size;
 
-/* print error message to stdout */
+/** \file shuffile_util.h
+ *  \ingroup shuffile
+ *  \brief shuffile utilies */
+
+/** print error message to stdout */
 void shuffile_err(const char *fmt, ...);
 
-/* print warning message to stdout */
+/** print warning message to stdout */
 void shuffile_warn(const char *fmt, ...);
 
-/* print message to stdout if shuffile_debug is set and it is >= level */
+/** print message to stdout if shuffile_debug is set and it is >= level */
 void shuffile_dbg(int level, const char *fmt, ...);
 
-/* print abort message and kill run */
+/** print abort message and kill run */
 void shuffile_abort(int rc, const char *fmt, ...);
 
-/* allocate size bytes, returns NULL if size == 0,
+/** allocate size bytes, returns NULL if size == 0,
  * calls shuffile_abort if allocation fails */
 #define SHUFFILE_MALLOC(X) shuffile_malloc(X, __FILE__, __LINE__);
 void* shuffile_malloc(size_t size, const char* file, int line);
 
-/* pass address of pointer to be freed, frees memory if not NULL and sets pointer to NULL */
+/** pass address of pointer to be freed, frees memory if not NULL and sets pointer to NULL */
 void shuffile_free(void* ptr);
 
-/* allocates a block of memory and aligns it to specified alignment */
+/** allocates a block of memory and aligns it to specified alignment */
 void* shuffile_align_malloc(size_t size, size_t align);
 
-/* frees a blocked allocated with a call to shuffile_align_malloc */
+/** frees a blocked allocated with a call to shuffile_align_malloc */
 void shuffile_align_free(void* buf);
 
-/* sends a NUL-terminated string to a process,
+/** sends a NUL-terminated string to a process,
  * allocates space and recieves a NUL-terminated string from a process,
  * can specify MPI_PROC_NULL as either send or recv rank */
 int shuffile_str_sendrecv(
@@ -56,7 +60,7 @@ int shuffile_swap_file_names(
   const char* dir_recv, MPI_Comm comm
 );
 
-/* returns true (non-zero) if flag on each process in comm is true */
+/** returns true (non-zero) if flag on each process in comm is true */
 int shuffile_alltrue(int flag, MPI_Comm comm);
 
 #include "kvtree.h"


### PR DESCRIPTION
Re-formatted the comments in the `.h` files to allow doxygen parsing for [generated documentation](https://ecp-veloc.github.io/component-user-docs/).