### PR TITLE
copy file metadata: owner, group, mode, timestamps

### DIFF
--- a/src/shuffile_io.c
+++ b/src/shuffile_io.c
@@ -536,6 +536,18 @@ int shuffile_write_pad_n(int n, const char** files, int* fds,
   return SHUFFILE_SUCCESS;
 }
 
+/* given a filename, return stat info */
+int shuffile_stat(const char* file, struct stat* statbuf)
+{
+  int rc = stat(file, statbuf);
+  if (rc < 0) {
+    shuffile_err("Error stat'ing file %s: errno=%d %s @ %s:%d",
+      file, errno, strerror(errno), __FILE__, __LINE__
+    );
+  }
+  return rc;
+}
+
 /* given a filename, return number of bytes in file */
 unsigned long shuffile_file_size(const char* file)
 {

--- a/src/shuffile_io.h
+++ b/src/shuffile_io.h
@@ -4,6 +4,8 @@
 #include <config.h>
 #include <stdarg.h>
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* compute crc32 */
 #include <zlib.h>
@@ -83,6 +85,9 @@ int shuffile_write_pad_n(
   unsigned long offset,
   unsigned long* filesizes
 );
+
+/** given a filename, return stat info */
+int shuffile_stat(const char* file, struct stat* statbuf);
 
 /** given a filename, return number of bytes in file */
 unsigned long shuffile_file_size(const char* file);


### PR DESCRIPTION
Copy file metadata when migrating files.  Copies owner uid, group gid, mode bits, and timestamps.