### PR TITLE
add key value configuration interface to shuffile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ To build KVTree:
     make clean
     make
     make install
-    make test
 
 To build shuffile:
 
     cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_KVTREE_PREFIX=`pwd`/install .
+    make
 
 # Testing
-Some simple test programs exist in the test directory.
+Some simple test programs exist in the test directory that are run by the `test` target.
 
-    mpicc -g -O0 -o test1 test1.c -I../install/include -L../install/lib64 -lkvtree -I../src -L../src -lshuffile
+    make test
 
 ## Release
 

--- a/src/shuffile.h
+++ b/src/shuffile.h
@@ -2,7 +2,6 @@
 #define SHUFFILE_H
 
 #include "mpi.h"
-#include "kvtree.h"
 
 /** \defgroup shuffile Shuffile
  *  \brief Shuffle files between MPI ranks
@@ -22,11 +21,41 @@ extern "C" {
 #define SHUFFILE_SUCCESS (0)
 #define SHUFFILE_FAILURE (1)
 
+#define SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE "MPI_BUF_SIZE"
+#define SHUFFILE_KEY_CONFIG_DEBUG "DEBUG"
+
 /** initialize library */
 int shuffile_init();
 
 /** shutdown library */
 int shuffile_finalize();
+
+/* needs to be above doxygen comment to get association right */
+typedef struct kvtree_struct kvtree;
+
+/**
+ * Get/set shuffile configuration values.
+ *
+ * The following configuration options can be set (type in parenthesis):
+ *   * "DEBUG" (int) - if non-zero, output debug information from inside
+ *     shuffile.
+ *   * "MPI_BUF_SIZE" (byte count [IN], int [OUT]) - MPI buffer size to chunk
+ *     file transfer. Must not exceed INT_MAX.
+ *   .
+ * Symbolic names SHUFFILE_KEY_CONFIG_FOO are defined in shuffile.h and should
+ * be used instead of the strings whenever possible to guard against typos in
+ * strings.
+ *
+ * \result If config != NULL, then return config on success.  If config == NULL
+ *         (you're querying the config) then return a new kvtree on success,
+ *         which must be kvtree_delete()ed by the caller. NULL on any failures.
+ * \param config The new configuration. If config == NULL, then return a kvtree
+ *               with all the configuration values.
+ *
+ */
+kvtree* shuffile_config(
+  const kvtree* config /** [IN] - kvtree of options */
+);
 
 /** associate a set of files with the calling process,
  * name of process is taken as rank in comm,

--- a/src/shuffile_util.h
+++ b/src/shuffile_util.h
@@ -9,6 +9,7 @@
 
 #define SHUFFILE_MAX_FILENAME (1024)
 
+extern int shuffile_debug;
 extern int shuffile_rank;
 extern char* shuffile_hostname;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,9 @@ TARGET_LINK_LIBRARIES(shuffile_test ${SHUFFILE_EXTERNAL_LIBS} shuffile)
 #ADD_TEST(NAME shuffile_test COMMAND ${MPIEXEC} -n6 -N3 -m block ./shuffile_test)
 SHUFFILE_ADD_TEST(shuffile_test 256 "")
 
+ADD_EXECUTABLE(test_config test_config.c)
+TARGET_LINK_LIBRARIES(test_config ${SHUFFILE_EXTERNAL_LIBS} shuffile)
+ADD_TEST(NAME test_config COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ./test_config)
 
 ####################
 # make a verbose "test" target named "check"

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -1,0 +1,193 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "shuffile.h"
+#include "shuffile_util.h"
+
+#include "kvtree.h"
+#include "kvtree_util.h"
+
+/* helper function to check for known options */
+void check_known_options(const kvtree* configured_values,
+                         const char* known_options[])
+{
+  /* report all unknown options (typos?) */
+  const kvtree_elem* elem;
+  for (elem = kvtree_elem_first(configured_values);
+       elem != NULL;
+       elem = kvtree_elem_next(elem))
+  {
+    const char* key = kvtree_elem_key(elem);
+
+    /* must be only one level deep, ie plain kev = value */
+    const kvtree* elem_hash = kvtree_elem_hash(elem);
+    if (kvtree_size(elem_hash) != 1) {
+      printf("Element %s has unexpected number of values: %d", key,
+           kvtree_size(elem_hash));
+      exit(EXIT_FAILURE);
+    }
+
+    const kvtree* kvtree_first_elem_hash =
+      kvtree_elem_hash(kvtree_elem_first(elem_hash));
+    if (kvtree_size(kvtree_first_elem_hash) != 0) {
+      printf("Element %s is not a pure value", key);
+      exit(EXIT_FAILURE);
+    }
+
+    /* check against known options */
+    const char** opt;
+    int found = 0;
+    for (opt = known_options; *opt != NULL; opt++) {
+      if (strcmp(*opt, key) == 0) {
+        found = 1;
+        break;
+      }
+    }
+    if (! found) {
+      printf("Unknown configuration parameter '%s' with value '%s'\n",
+        kvtree_elem_key(elem),
+        kvtree_elem_key(kvtree_elem_first(kvtree_elem_hash(elem)))
+      );
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+
+/* helper function to check option values in kvtree against expected values */
+void check_options(const int exp_debug, const int exp_mpi_buf_size)
+{
+  kvtree* config = shuffile_config(NULL);
+  if (config == NULL) {
+    printf("shuffile_config failed\n");
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_debug;
+  if (kvtree_util_get_int(config, SHUFFILE_KEY_CONFIG_DEBUG, &cfg_debug) !=
+    KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from shuffile_config\n",
+           SHUFFILE_KEY_CONFIG_DEBUG);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_debug != exp_debug) {
+    printf("shuffile_config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_debug, SHUFFILE_KEY_CONFIG_DEBUG,
+           exp_debug);
+    exit(EXIT_FAILURE);
+  }
+
+  int cfg_mpi_buf_size;
+  if (kvtree_util_get_int(config, SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE,
+                          &cfg_mpi_buf_size) != KVTREE_SUCCESS)
+  {
+    printf("Could not get %s from shuffile_config\n",
+           SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE);
+    exit(EXIT_FAILURE);
+  }
+  if (cfg_mpi_buf_size != exp_mpi_buf_size) {
+    printf("shuffile_config returned unexpected value %d for %s. Expected %d.\n",
+           cfg_mpi_buf_size, SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE,
+           exp_mpi_buf_size);
+    exit(EXIT_FAILURE);
+  }
+
+  static const char* known_options[] = {
+    SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE,
+    SHUFFILE_KEY_CONFIG_DEBUG,
+    NULL
+  };
+  check_known_options(config, known_options);
+
+  kvtree_delete(&config);
+}
+
+int
+main(int argc, char *argv[]) {
+    int rc;
+    kvtree* shuffile_config_values = kvtree_new();
+
+    MPI_Init(&argc, &argv);
+
+    rc = shuffile_init();
+    if (rc != SHUFFILE_SUCCESS) {
+        printf("shuffile_init() failed (error %d)\n", rc);
+        return EXIT_FAILURE;
+    }
+
+    /* needs to be afater shuffile_init to catch initialization of globals */
+    int old_shuffile_debug = shuffile_debug;
+    int old_shuffile_mpi_buf_size = shuffile_mpi_buf_size;
+
+    int new_shuffile_debug = !old_shuffile_debug;
+    int new_shuffile_mpi_buf_size = old_shuffile_mpi_buf_size + 1;
+
+    check_options(old_shuffile_debug, old_shuffile_mpi_buf_size);
+
+    /* check shuffile configuration settings */
+    rc = kvtree_util_set_int(shuffile_config_values, SHUFFILE_KEY_CONFIG_DEBUG,
+                             new_shuffile_debug);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return EXIT_FAILURE;
+    }
+
+    printf("Configuring shuffile (first set of options)...\n");
+    if (shuffile_config(shuffile_config_values) == NULL) {
+        printf("shuffile_config() failed\n");
+        return EXIT_FAILURE;
+    }
+
+    /* check options just set */
+
+    if (shuffile_debug != new_shuffile_debug) {
+        printf("shuffile_config() failed to set %s: %d != %d\n",
+               SHUFFILE_KEY_CONFIG_DEBUG, shuffile_debug, new_shuffile_debug);
+        return EXIT_FAILURE;
+    }
+
+    check_options(new_shuffile_debug, old_shuffile_mpi_buf_size);
+
+    /* configure remainder of options */
+    kvtree_delete(&shuffile_config_values);
+    shuffile_config_values = kvtree_new();
+
+    rc = kvtree_util_set_int(shuffile_config_values, SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE,
+                             new_shuffile_mpi_buf_size);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return EXIT_FAILURE;
+    }
+
+    printf("Configuring shuffile (second set of options)...\n");
+    if (shuffile_config(shuffile_config_values) == NULL) {
+        printf("shuffile_config() failed\n");
+        return EXIT_FAILURE;
+    }
+
+    /* check all options once more */
+
+    if (shuffile_debug != new_shuffile_debug) {
+        printf("shuffile_config() failed to set %s: %d != %d\n",
+               SHUFFILE_KEY_CONFIG_DEBUG, shuffile_debug, new_shuffile_debug);
+        return EXIT_FAILURE;
+    }
+
+    if (shuffile_mpi_buf_size != new_shuffile_mpi_buf_size) {
+        printf("shuffile_config() failed to set %s: %d != %d\n",
+               SHUFFILE_KEY_CONFIG_MPI_BUF_SIZE, shuffile_mpi_buf_size,
+               old_shuffile_mpi_buf_size); 
+        return EXIT_FAILURE;
+    }
+
+    check_options(new_shuffile_debug, new_shuffile_mpi_buf_size);
+
+    rc = shuffile_finalize();
+    if (rc != SHUFFILE_SUCCESS) {
+        printf("shuffile_finalize() failed (error %d)\n", rc);
+        return EXIT_FAILURE;
+    }
+
+    MPI_Finalize();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This pull request adds a configuration interface to filo, similar in functionality to the one in AXL. Specifically it adds a new function shuffile_config:

```
/**
 * Get/set shuffile configuration values.
 *
 * The following configuration options can be set (type in parenthesis):
 *   * "DEBUG" (int) - if non-zero, output debug information from inside
 *     shuffile.
 *   * "MPI_BUF_SIZE" (byte count [IN], int [OUT]) - MPI buffer size to chunk
 *     file transfer. Must not exceed INT_MAX.
 *   .
 * Symbolic names SHUFFILE_KEY_CONFIG_FOO are defined in shuffile.h and should
 * be used instead of the strings whenever possible to guard against typos in
 * strings.
 *
 * \result If config != NULL, then return config on success.  If config=NULL                             *         (you're querying the config) then return a new kvtree on success.
 *         NULL on any failures.
 * \param config The new configuration. If config=NULL, then return a kvtree
 *                with all the configuration values.
 *
 */                                                                                                     kvtree* shuffile_config(
  const kvtree* config /** [IN] - kvtree of options */
);
```

as well as a new test test_config to check functionality of this interface.

Querying options will return shuffile's the current value of the options.

Options can be configured multiple times at runtime and it is the user's responsibility ensure that this does not lead to problems.