### PR TITLE
Incremental release v0.0.4

### DIFF
--- a/src/shuffile_util.c
+++ b/src/shuffile_util.c
@@ -26,8 +26,6 @@
 #include "shuffile_util.h"
 #include "shuffile_io.h"
 
-#define SHUFFILE_VERSION "1.0"
-
 int shuffile_debug = 1;
 
 int shuffile_rank = -1;

--- a/src/shuffile_util.h
+++ b/src/shuffile_util.h
@@ -7,6 +7,8 @@
 #define SHUFFILE_SUCCESS (0)
 #define SHUFFILE_FAILURE (1)
 
+#define SHUFFILE_VERSION "0.0.4"
+
 #define SHUFFILE_MAX_FILENAME (1024)
 
 extern int shuffile_debug;


### PR DESCRIPTION
Move `SHUFFILE_VERSION` to _shuffile_util.h_ and update to v0.0.4 for tagging a new release.

This is in preparation for SCR 3.0rc1 and 3.0 releases and addresses the second item of #12